### PR TITLE
map bug fixes - 

### DIFF
--- a/viz/index.js
+++ b/viz/index.js
@@ -86,9 +86,11 @@ const emptyTractInfoBox = () => {
 
 const getBikeStationInfoPopup = (station) => {
   let dateString = new Date(station.first).toDateString();
+  let lastDateString = new Date(station.last).toDateString();
   return `<div class='bike-station-info-popup'>
             <p class='bike-station-name'>${station.name}</p>
             <p>First ride: ${dateString}</p>
+            <p>Last ride: ${lastDateString}</p>
           </div>`;
 };
 

--- a/viz/map.js
+++ b/viz/map.js
@@ -317,7 +317,7 @@ const addBikeStationLayer = (year = currentYear) => {
 const createBikeStationLayerGroup = (year) => {
   let bikeStationMarkerLayerGroup = L.layerGroup();
   let firstYear = Object.keys(stationYears)[0];
-  for (let i = firstYear; i < currentYear + 1; i++) {
+  for (let i = firstYear; i < year + 1; i++) {
     const stations = stationYears[i] || [];
     stations.forEach((station) => {
       if (parseInt(station.last) < year) {

--- a/viz/map.js
+++ b/viz/map.js
@@ -320,7 +320,7 @@ const createBikeStationLayerGroup = (year) => {
   for (let i = firstYear; i < currentYear + 1; i++) {
     const stations = stationYears[i] || [];
     stations.forEach((station) => {
-      if (station.last < currentYear) {
+      if (parseInt(station.last) < year) {
         console.log("found a disappearing station!", station);
         return;
       }


### PR DESCRIPTION
removed stations when last ride occurs before year selected

this happened because the datetime was being treated like an integer year

also added the last ride to the tooltip for the stations